### PR TITLE
Fix convos-api spec URL

### DIFF
--- a/doc/develop.md
+++ b/doc/develop.md
@@ -224,7 +224,7 @@ Convos has an OpenAPI powered REST API. The specification is used to both
 generate Perl code for validation, and to generate documentation. Resources:
 
 * [Documentation](/api.html)
-* [Specification](https://github.com/convos-chat/convos/blob/master/public/convos-api.json)
+* [Specification](https://github.com/convos-chat/convos/blob/master/public/convos-api.yaml)
 * [OpenAPI](https://www.openapis.org/)
 * [Mojolicious::Plugin::OpenAPI](/doc/Mojolicious/Plugin/OpenAPI)
 


### PR DESCRIPTION
Update URL to API specification from `convos-api.json` -> `convos-api.yaml`