### PR TITLE
Document setting listen address with env variable

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -163,6 +163,13 @@ Examples:
     CONVOS_REQUEST_BASE=https://convos.example.com/
     CONVOS_REQUEST_BASE=https://example.com/apps/convos
 
+### `MOJO_LISTEN`
+
+Used to set the address Convos should listen on. If the `--listen` argument is
+given when starting convos, that value will be used instead.
+
+Default: `http://*:3000`
+
 ### `CONVOS_REVERSE_PROXY`
 
 The `CONVOS_REVERSE_PROXY` environment variable must be set to "1" to enable


### PR DESCRIPTION
fixes #18 

I put this in the "Configuration" section for now. I'm not sure if it's better to put it there or in the docker documentation though. It's the only environment variable in that section that starts with "MOJO_" instead of "CONVOS_".