### PR TITLE
Fix code block style in config.md

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -193,7 +193,7 @@ connection name. Example:
 1. You have a connection ID "irc-localhost". (Shown as "localhost" in the sidebar)
 2. Set the following environment variable to enable WEBIRC:
 
-    CONVOS_WEBIRC_PASSWORD_LOCALHOST=SomeSuperSecretPassword
+        CONVOS_WEBIRC_PASSWORD_LOCALHOST=SomeSuperSecretPassword
 
 ## Global config settings
 


### PR DESCRIPTION
To nest a code block in a list,  indentation of at least 8 spaces is required.

Current broken behavior:

![image](https://github.com/user-attachments/assets/847ad798-9ffd-4cbc-a482-5939828fe617)
